### PR TITLE
kart no longer retained momentum after falling

### DIFF
--- a/GGK/Assets/DynamicRecovery.cs
+++ b/GGK/Assets/DynamicRecovery.cs
@@ -220,6 +220,12 @@ public class DynamicRecovery : MonoBehaviour
         rb.angularVelocity = Vector3.zero;
         rb.useGravity = false;
 
+        if(kartMovementScript != null)
+        {
+            kartMovementScript.Recover();
+        }
+
+
         yield return new WaitForSeconds(1.3f); // hold black screen for effect
 
         if (kartMovementScript != null)

--- a/GGK/Assets/Scenes/TrackScenes/All-Nighter Expressway/GSP_FinalsBrickRoad.unity
+++ b/GGK/Assets/Scenes/TrackScenes/All-Nighter Expressway/GSP_FinalsBrickRoad.unity
@@ -9349,7 +9349,7 @@ MeshRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1939664223}
-  m_Enabled: 1
+  m_Enabled: 0
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1

--- a/GGK/Assets/Scripts/DriverScripts/NEWDriver.cs
+++ b/GGK/Assets/Scripts/DriverScripts/NEWDriver.cs
@@ -1122,4 +1122,19 @@ public class NEWDriver : MonoBehaviour
         kartModel.localRotation = Quaternion.identity; // Reset kart model rotation after stun
         isStunned = false;
     }
+
+    public void Recover()
+    {
+        StopCoroutine(DriftHopEnabler());
+        StopCoroutine(TurboTwist());
+        StopCoroutine(Boost(driftBoostForce, 0.4f));
+
+        driftTime = 0f;
+        isDrifting = false;
+        AirTricking = false;
+        airTrickCount = 0;
+        airTrickInProgress = false;
+        airTrickTween?.Kill();
+        driftRotationTween?.Kill();
+    }
 }


### PR DESCRIPTION
After falling into the death plane, player karts no longer retain momentum/boosts from air tricking