### PR TITLE
New Item Block Type

### DIFF
--- a/GGK/.github/copilot-instructions.md
+++ b/GGK/.github/copilot-instructions.md
@@ -2,13 +2,12 @@
 - Project name: GGK
 - Unity version: Unity 2022.3.38f1
 - Active scene:
-  - Name: StartScene
   - Tags:
     - Untagged, Respawn, Finish, EditorOnly, MainCamera, Player, GameController, Ground, Checkpoint, Trigger, Startpoint, ItemBox, Kart, Projectile, Boost, Hazard, slowDown, GameManager, UpgradeBox, Options, DeathZone, Obstacle, Rock, Road, Shield, ProjectileBrick
   - Layers:
     - Default, TransparentFX, Ignore Raycast, ItemBox, Water, UI, Bonkable, Obstacle, Projectile
 - Active game object:
-  - Name: MultiplayerManager
-  - Tag: Untagged
-  - Layer: Default
+  - Name: RandomRespawnTypeBrick
+  - Tag: ItemBox
+  - Layer: ItemBox
 <!-- UNITY CODE ASSIST INSTRUCTIONS END -->

--- a/GGK/Assets/Prefabs/RandomRespawnTypeBrick.prefab
+++ b/GGK/Assets/Prefabs/RandomRespawnTypeBrick.prefab
@@ -1,0 +1,182 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6693033099988274845
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3370060001277796832}
+  - component: {fileID: 3714890461545147978}
+  - component: {fileID: 4233392266948647704}
+  - component: {fileID: 1538687228604790719}
+  - component: {fileID: 3900636016606846724}
+  - component: {fileID: 6548136241964284813}
+  - component: {fileID: 6159235170077489779}
+  m_Layer: 3
+  m_Name: RandomRespawnTypeBrick
+  m_TagString: ItemBox
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3370060001277796832
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6693033099988274845}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 2.5, y: 2.5, z: 2.5}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &3714890461545147978
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6693033099988274845}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &4233392266948647704
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6693033099988274845}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &1538687228604790719
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6693033099988274845}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &3900636016606846724
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6693033099988274845}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 116
+  m_CollisionDetection: 0
+--- !u!114 &6548136241964284813
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6693033099988274845}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  GlobalObjectIdHash: 1896712302
+  InScenePlacedSourceGlobalObjectIdHash: 0
+  AlwaysReplicateAsRoot: 0
+  SynchronizeTransform: 1
+  ActiveSceneSynchronization: 0
+  SceneMigrationSynchronization: 1
+  SpawnWithObservers: 1
+  DontDestroyWithOwner: 0
+  AutoObjectParentSync: 1
+--- !u!114 &6159235170077489779
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6693033099988274845}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: baddcda8225ec5240a122f53e3f7bb42, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemType: -1
+  isActive: 1
+  isTimerActive: 0
+  timerDuration: 0
+  randomRespawnType: 1
+  randomizeOnStart: 1
+  ItemBrickMaterials:
+  - {fileID: 2100000, guid: 046c84f71ade89f4c82d6c4b35fb17e6, type: 2}
+  - {fileID: 2100000, guid: 554d8814f2ed6b44f8706d1b40f349b2, type: 2}
+  - {fileID: 2100000, guid: 89280477bae9dec4cafafa75d87c4d84, type: 2}
+  - {fileID: 2100000, guid: 6612c9721643ae44eb99979a3363da5f, type: 2}
+  - {fileID: 2100000, guid: 19a4cac6d11b22248b3b7eb69764341d, type: 2}

--- a/GGK/Assets/Prefabs/RandomRespawnTypeBrick.prefab.meta
+++ b/GGK/Assets/Prefabs/RandomRespawnTypeBrick.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6b0d91b14c515b54abf6eaa8e78a6b20
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/GGK/Assets/Scenes/TrackScenes/DormRoom/LD_RITDorm.unity
+++ b/GGK/Assets/Scenes/TrackScenes/DormRoom/LD_RITDorm.unity
@@ -10341,6 +10341,71 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1009594998}
   m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1001 &1017361522
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3370060001277796832, guid: 6b0d91b14c515b54abf6eaa8e78a6b20, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 237.69
+      objectReference: {fileID: 0}
+    - target: {fileID: 3370060001277796832, guid: 6b0d91b14c515b54abf6eaa8e78a6b20, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -67.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3370060001277796832, guid: 6b0d91b14c515b54abf6eaa8e78a6b20, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 9.79
+      objectReference: {fileID: 0}
+    - target: {fileID: 3370060001277796832, guid: 6b0d91b14c515b54abf6eaa8e78a6b20, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3370060001277796832, guid: 6b0d91b14c515b54abf6eaa8e78a6b20, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3370060001277796832, guid: 6b0d91b14c515b54abf6eaa8e78a6b20, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3370060001277796832, guid: 6b0d91b14c515b54abf6eaa8e78a6b20, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3370060001277796832, guid: 6b0d91b14c515b54abf6eaa8e78a6b20, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3370060001277796832, guid: 6b0d91b14c515b54abf6eaa8e78a6b20, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3370060001277796832, guid: 6b0d91b14c515b54abf6eaa8e78a6b20, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6548136241964284813, guid: 6b0d91b14c515b54abf6eaa8e78a6b20, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1435936291
+      objectReference: {fileID: 0}
+    - target: {fileID: 6548136241964284813, guid: 6b0d91b14c515b54abf6eaa8e78a6b20, type: 3}
+      propertyPath: InScenePlacedSourceGlobalObjectIdHash
+      value: 1896712302
+      objectReference: {fileID: 0}
+    - target: {fileID: 6693033099988274845, guid: 6b0d91b14c515b54abf6eaa8e78a6b20, type: 3}
+      propertyPath: m_Name
+      value: RandomRespawnTypeBrick
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6b0d91b14c515b54abf6eaa8e78a6b20, type: 3}
 --- !u!1 &1054217041
 GameObject:
   m_ObjectHideFlags: 0
@@ -19964,3 +20029,4 @@ SceneRoots:
   - {fileID: 161564209}
   - {fileID: 652078622}
   - {fileID: 1907956634}
+  - {fileID: 1017361522}

--- a/GGK/Assets/Scripts/ItemScripts/ItemHolder.cs
+++ b/GGK/Assets/Scripts/ItemScripts/ItemHolder.cs
@@ -804,7 +804,7 @@ public class ItemHolder : NetworkBehaviour
         StartCoroutine(currentSpinCoroutine);
     }
 
-    private ItemTypeEnum RandomItemType()
+    public static ItemTypeEnum RandomItemType()
     {
         return (ItemTypeEnum)UnityEngine.Random.Range(0, (int)Enum.GetValues(typeof(ItemTypeEnum)).Cast<ItemTypeEnum>().Max() + 1);
     }

--- a/GGK/ProjectSettings/ProjectSettings.asset
+++ b/GGK/ProjectSettings/ProjectSettings.asset
@@ -140,7 +140,8 @@ PlayerSettings:
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
   bundleVersion: 1.0
-  preloadedAssets: []
+  preloadedAssets:
+  - {fileID: 11400000, guid: 144cb8da0562d214987e08eccf6581af, type: 2}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1


### PR DESCRIPTION
Item respawn lowered to 2.5s across the board

Random Respawn Type Item Added (RandomRespawnTypeBrick.prefab). This block type respawns as a random type when it respawns.

Two togglable Booleans added to the item box scrips as serialized fields RandomRespawnType - Makes the box come back as a random type excluding the upgrade block. RandomizeOnStart - Makes the box become a random type at the start of the race. This allows you to set the type of a block at the start of a race or not.

Random Respawn Type Item Box has these two on by default the rest of the block types have them off.

There is a single one of these blocks preplaced right before the first boost pad on the right of the waterbottle of LD_RITDorm for testing.