### PR TITLE
Fix for issue #315

### DIFF
--- a/GGK/Assets/Materials/Sprites/Materials/dev_texture_grass.mat
+++ b/GGK/Assets/Materials/Sprites/Materials/dev_texture_grass.mat
@@ -49,7 +49,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 0}
+        m_Texture: {fileID: 2800000, guid: 7a1d80f683ea9d647848b8dcc6b3e127, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MetallicGlossMap:

--- a/GGK/Assets/Scenes/StartScene.unity
+++ b/GGK/Assets/Scenes/StartScene.unity
@@ -2039,6 +2039,14 @@ PrefabInstance:
       propertyPath: eventSystem
       value: 
       objectReference: {fileID: 193614648}
+    - target: {fileID: 8115276711092057341, guid: 296c294481137d24ea35fe1f939b0d17, type: 3}
+      propertyPath: buttonOut
+      value: 
+      objectReference: {fileID: 1448914252}
+    - target: {fileID: 8115276711092057341, guid: 296c294481137d24ea35fe1f939b0d17, type: 3}
+      propertyPath: eventSystem
+      value: 
+      objectReference: {fileID: 193614648}
     - target: {fileID: 8191498011181247536, guid: 296c294481137d24ea35fe1f939b0d17, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -3644,7 +3652,7 @@ PrefabInstance:
     - target: {fileID: 1864226820401193883, guid: 792e634304d858b469595c576934e308, type: 3}
       propertyPath: buttonOut
       value: 
-      objectReference: {fileID: 904248808}
+      objectReference: {fileID: 2037305746}
     - target: {fileID: 1864226820401193883, guid: 792e634304d858b469595c576934e308, type: 3}
       propertyPath: eventSystem
       value: 

--- a/GGK/Assets/Scenes/StartScene.unity
+++ b/GGK/Assets/Scenes/StartScene.unity
@@ -1760,7 +1760,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 628999392}
   m_HandleRect: {fileID: 628999391}
   m_Direction: 2
-  m_Value: 0
+  m_Value: 1
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -3644,7 +3644,7 @@ PrefabInstance:
     - target: {fileID: 1864226820401193883, guid: 792e634304d858b469595c576934e308, type: 3}
       propertyPath: buttonOut
       value: 
-      objectReference: {fileID: 2037305746}
+      objectReference: {fileID: 904248808}
     - target: {fileID: 1864226820401193883, guid: 792e634304d858b469595c576934e308, type: 3}
       propertyPath: eventSystem
       value: 
@@ -3778,8 +3778,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1254118460}
+  m_Children: []
   m_Father: {fileID: 444550953}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -4352,11 +4351,11 @@ RectTransform:
   m_LocalScale: {x: 1.0561956, y: 1.0561956, z: 1.0561956}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1254118460}
+  m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.00090026855, y: 135}
+  m_AnchoredPosition: {x: -0.00090026855, y: 1058.466}
   m_SizeDelta: {x: 650, y: 0}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!114 &1567664993
@@ -5587,3 +5586,4 @@ SceneRoots:
   - {fileID: 376136322}
   - {fileID: 1011990453}
   - {fileID: 1499987440}
+  - {fileID: 1567664992}

--- a/GGK/Assets/Scripts/GameManagers/ControlsHandler.cs
+++ b/GGK/Assets/Scripts/GameManagers/ControlsHandler.cs
@@ -13,7 +13,7 @@ public class ControlsHandler : MonoBehaviour
     public Image controllerInputs;
 
     /// <summary>
-    /// This is so when this panel opens, the button selected goes to this button set
+    /// This is so when this panel opens and closes, the button selected goes to this button set
     /// </summary>
     [Header("ButtonNavigation Settings")]
     [SerializeField] private EventSystem eventSystem;

--- a/GGK/Assets/Scripts/GameManagers/OptionsHandler.cs
+++ b/GGK/Assets/Scripts/GameManagers/OptionsHandler.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
 using DG.Tweening.Core.Easing;
+using UnityEngine.EventSystems;
 
 public class OptionsHandler : MonoBehaviour
 {
@@ -31,6 +32,13 @@ public class OptionsHandler : MonoBehaviour
     public TMP_InputField heightInputField;
 
     private bool initalizing;
+
+    /// <summary>
+    /// This is so when this panel closes, the button selected goes to this button set
+    /// </summary>
+    [Header("ButtonNavigation Settings")]
+    [SerializeField] private EventSystem eventSystem;
+    [SerializeField] private GameObject buttonOut;
 
     private void Update()
     {
@@ -153,6 +161,8 @@ public class OptionsHandler : MonoBehaviour
     // Close Options
     public void Close()
     {
+        // When this panel closes this is the first button to be hovered outside of the panel
+        eventSystem.SetSelectedGameObject(buttonOut);
         gameObject.SetActive(false);
         optionsData.GameManager.RefreshSelected();
     }


### PR DESCRIPTION
Solution: ''Controls" and its "Close" Button stays in "selected" state #315"
 Before when you left the controls menu to the home page the program would set the controls button as selected. But it was the only button that did that. Now the options menu does the same for uniformity. I think that was the best option for helping with backwards navigation with controllers.